### PR TITLE
Fix hotkey and spinner style

### DIFF
--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -288,14 +288,14 @@ function setupFloatingBallHotkey() {
                                 (hotkeyParts.includes('shift') || !hotkeysPressed.has('shift'));
         
         // 如果按键组合匹配配置的快捷键，且没有额外的修饰键
-        if (allKeysPressed && noExtraModifiers && !config.disableFloatingBall) {
+        if (allKeysPressed && noExtraModifiers) {
             // 防止事件继续传播和默认行为
             event.preventDefault();
             event.stopPropagation();
-            
+
             // 通过自定义事件来触发翻译
             document.dispatchEvent(new CustomEvent('fluentread-toggle-translation'));
-            
+
             if (isDev) {
                 console.log('[FluentRead] 触发悬浮球翻译');
             }

--- a/entrypoints/style.css
+++ b/entrypoints/style.css
@@ -4,7 +4,7 @@
 }
 .fluent-read-loading {
     border: 3px solid #f3f3f3; /* 轨迹灰色 */
-    border-top: 3px solid blue;   /* 主色调，首次翻译蓝色、缓存应改为绿色 */
+    border-top: 3px solid #999;   /* 中性配色，保持简洁 */
     border-radius: 50%;
     width: 12px;
     height: 12px;

--- a/entrypoints/utils/icon.ts
+++ b/entrypoints/utils/icon.ts
@@ -115,7 +115,7 @@ export function insertLoadingSpinner(
 ): HTMLElement {
   const spinner = document.createElement("span");
   spinner.className = "fluent-read-loading";
-  if (isCache) spinner.style.borderTop = "3px solid green"; // 存在缓存时改为绿色
+  // 统一使用默认样式以保持简洁
   node.appendChild(spinner);
   return spinner;
 }


### PR DESCRIPTION
## Summary
- allow full page translate hotkey even when floating ball is disabled
- use a neutral spinner colour and simplify spinner creation

## Testing
- `pnpm -v` *(fails: unable to download)*

------
https://chatgpt.com/codex/tasks/task_e_687ef84a5ae8832b9c709da9f622500e